### PR TITLE
[19] - Muda nomeação de botao `remover` para `arquivar`.

### DIFF
--- a/src/components/SessionsList/SessionsList.tsx
+++ b/src/components/SessionsList/SessionsList.tsx
@@ -49,7 +49,7 @@ const SessionsList: React.FC = () => {
             render: (_: any, record: any) => (
                 <Space size="middle">
                   <EditDeletePatientButton>Editar</EditDeletePatientButton>
-                  <EditDeletePatientButton>Remover</EditDeletePatientButton>
+                  <EditDeletePatientButton>Arquivar</EditDeletePatientButton>
                 </Space>
               ),
         },


### PR DESCRIPTION
## Qual é o propósito desse PR?
- Mudar nomeação de botao `remover` para `arquivar`.

## Lista do que foi feito:
- Muda nome de `Remover` para `Arquivar`.

## Há algo fora do propósito do card ?
- Não.

## Como pode ser testado?
- Acessar a rota `/sessions` e verificar botão em `Ações`, deve estar como `Arquivar` e não `Remover`.
____
**[Issue Link](https://github.com/william-ribeiro/web-healthy-mind/issues/19)**
