### PR TITLE
1 react roles visualização específica de funcionalidades de menu por tipo de usuário

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,15 +47,6 @@ const App: React.FC = () => {
           />
 
           <Route
-            path="/patients-dashboard"
-            element={
-              <PrivateRoute redirectTo="/">
-                <Dashboard />
-              </PrivateRoute>
-            }
-          />
-
-          <Route
             path="/register-patient"
             element={
               <PrivateRoute redirectTo="/">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,15 @@ const App: React.FC = () => {
           />
 
           <Route
+            path="/patients-dashboard"
+            element={
+              <PrivateRoute redirectTo="/">
+                <Dashboard />
+              </PrivateRoute>
+            }
+          />
+
+          <Route
             path="/register-patient"
             element={
               <PrivateRoute redirectTo="/">

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -11,7 +11,6 @@ import {
 } from './DashboardStyles';
 
 const Dashboard: React.FC = () => {
-  const currentPath = window.location.pathname;
   const { Content, Footer } = Layout;
   const userRole = getUserRole();
 
@@ -23,33 +22,35 @@ const Dashboard: React.FC = () => {
           style={{
             margin: '25px 20px',
           }}>
-          <LayoutBackground>
-            <Row gutter={[0, 40]} wrap>
-              <Col span={24}>
-                <PatientGridItem>
-                  <PatientItemTitle>Titulo da sessao</PatientItemTitle>
-                  <Divider />
-                  <Descriptions layout="vertical" bordered>
-                    <Descriptions.Item label="Status" span={3}>
-                      <Badge status="processing" text="Running" />
-                    </Descriptions.Item>
-                  </Descriptions>
-                </PatientGridItem>
-              </Col>
-              <Col span={24}>
-                <PatientGridItem>
-                  <PatientItemTitle>Titulo da sessao</PatientItemTitle>
-                  <Divider />
-                  <Descriptions layout="vertical" bordered>
-                    <Descriptions.Item label="Status" span={3}>
-                      <Badge status="processing" text="Running" />
-                    </Descriptions.Item>
-                  </Descriptions>
-                </PatientGridItem>
-              </Col>
-            </Row>
-          </LayoutBackground>
-          {userRole !== 'patient' && (
+          {userRole === 'patient' && (
+            <LayoutBackground>
+              <Row gutter={[0, 40]} wrap>
+                <Col span={24}>
+                  <PatientGridItem>
+                    <PatientItemTitle>Titulo da sessao</PatientItemTitle>
+                    <Divider />
+                    <Descriptions layout="vertical" bordered>
+                      <Descriptions.Item label="Status" span={3}>
+                        <Badge status="processing" text="Running" />
+                      </Descriptions.Item>
+                    </Descriptions>
+                  </PatientGridItem>
+                </Col>
+                <Col span={24}>
+                  <PatientGridItem>
+                    <PatientItemTitle>Titulo da sessao</PatientItemTitle>
+                    <Divider />
+                    <Descriptions layout="vertical" bordered>
+                      <Descriptions.Item label="Status" span={3}>
+                        <Badge status="processing" text="Running" />
+                      </Descriptions.Item>
+                    </Descriptions>
+                  </PatientGridItem>
+                </Col>
+              </Row>
+            </LayoutBackground>
+          )}
+          {userRole === 'professional' && (
             <LayoutBackground>
               <Row gutter={[20, 20]} wrap>
                 <Col>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,9 @@
 import { Col, Layout, Row, Divider, Descriptions, Badge } from 'antd';
 import { getUserRole } from 'src/services/Auth/service';
+import moment from 'moment';
+// import { useSessionsList } from 'src/services/Session/hooks';
 import SideMenu from '../SideMenu/SideMenu';
+// import { ISessionParser } from 'src/services/Session/dtos/ISessionParser';
 import {
   GridItem,
   PatientGridItem,
@@ -13,7 +16,55 @@ import {
 const Dashboard: React.FC = () => {
   const { Content, Footer } = Layout;
   const userRole = getUserRole();
-
+  // const filterParams = { page: 1 };
+  // const { data: sessionsList } = useSessionsList(filterParams);
+  const sessionsList = [
+    {
+      patientId: 1,
+      status: 'Agendado',
+      subject: 'Hipnose',
+      duration: '01:00',
+      type: 'Individual',
+      comments: 'Agendamento de sessão 01',
+      service: 'Remote',
+      resourceId: 1,
+      appointmentDate: '2023-08-10 16:00',
+    },
+    {
+      patientId: 2,
+      status: 'Cancelado',
+      subject: 'Conflito',
+      duration: '00:30',
+      type: 'Casal',
+      comments: 'Agendamento de sessão 02',
+      service: 'Remote',
+      resourceId: 1,
+      appointmentDate: '2023-09-03 16:00',
+    },
+    {
+      patientId: 3,
+      status: 'Atendido',
+      subject: 'Constelacao Familiar',
+      duration: '02:00',
+      type: 'Grupo',
+      comments: 'Agendamento de sessão 03',
+      service: 'Remote',
+      resourceId: 1,
+      appointmentDate: '2023-05-25 16:00',
+    },
+    {
+      patientId: 4,
+      status: 'Agendado',
+      subject: 'Fobia',
+      duration: '00:45',
+      type: 'Individual',
+      comments: 'Agendamento de sessão 04',
+      service: 'Remote',
+      resourceId: 1,
+      appointmentDate: '2023-02-11 16:00',
+    },
+  ];
+  // console.log(sessionsList);
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <SideMenu />
@@ -25,28 +76,43 @@ const Dashboard: React.FC = () => {
           {userRole === 'patient' && (
             <LayoutBackground>
               <Row gutter={[0, 40]} wrap>
-                <Col span={24}>
-                  <PatientGridItem>
-                    <PatientItemTitle>Titulo da sessao</PatientItemTitle>
-                    <Divider />
-                    <Descriptions layout="vertical" bordered>
-                      <Descriptions.Item label="Status" span={3}>
-                        <Badge status="processing" text="Running" />
-                      </Descriptions.Item>
-                    </Descriptions>
-                  </PatientGridItem>
-                </Col>
-                <Col span={24}>
-                  <PatientGridItem>
-                    <PatientItemTitle>Titulo da sessao</PatientItemTitle>
-                    <Divider />
-                    <Descriptions layout="vertical" bordered>
-                      <Descriptions.Item label="Status" span={3}>
-                        <Badge status="processing" text="Running" />
-                      </Descriptions.Item>
-                    </Descriptions>
-                  </PatientGridItem>
-                </Col>
+                {sessionsList.map((session) => {
+                  return (
+                    <Col span={24} key={session.patientId}>
+                      <PatientGridItem>
+                        <Divider orientation="left" plain>
+                          <PatientItemTitle>{session.subject}</PatientItemTitle>
+                        </Divider>
+                        <Descriptions layout="vertical" size="middle" bordered>
+                          <Descriptions.Item
+                            label="Data da sessão"
+                            span={1}
+                            style={{ marginBottom: 20 }}>
+                            {moment(session.appointmentDate).format('DD/MM/YYYY')}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Status" span={1}>
+                            {session.status}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Duração da sessão" span={1}>
+                            {session.duration}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Tipo de sessão" span={1}>
+                            {session.type}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Tipo de serviço" span={1}>
+                            {session.service}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Recurso" span={1}>
+                            {session.resourceId}
+                          </Descriptions.Item>
+                          <Descriptions.Item label="Anotações complementares" span={3}>
+                            {session.comments}
+                          </Descriptions.Item>
+                        </Descriptions>
+                      </PatientGridItem>
+                    </Col>
+                  );
+                })}
               </Row>
             </LayoutBackground>
           )}

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,64 +1,69 @@
 import { Col, Layout, Row } from 'antd';
+import { getUserRole } from 'src/services/Auth/service';
 import SideMenu from '../SideMenu/SideMenu';
 import { GridItem, ItemNumber, ItemTitle, LayoutBackground } from './DashboardStyles';
 
 const Dashboard: React.FC = () => {
+  const currentPath = window.location.pathname;
   const { Content, Footer } = Layout;
+  const userRole = getUserRole();
 
   return (
-    <Layout>
+    <Layout style={{ minHeight: '100vh' }}>
       <SideMenu />
       <Layout>
         <Content
           style={{
             margin: '25px 20px',
           }}>
-          <LayoutBackground>
-            <Row gutter={[20, 20]} wrap>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Sessões agendadas (dia)</ItemTitle>
-                  <ItemNumber>5</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Sessões agendadas (mês)</ItemTitle>
-                  <ItemNumber>15</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Sessões canceladas (mês)</ItemTitle>
-                  <ItemNumber>1</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Total de pacientes cadastrados</ItemTitle>
-                  <ItemNumber>61152</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Total de sessões (individuais)</ItemTitle>
-                  <ItemNumber>5</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Total de sessões (dupla)</ItemTitle>
-                  <ItemNumber>5</ItemNumber>
-                </GridItem>
-              </Col>
-              <Col>
-                <GridItem>
-                  <ItemTitle>Total de sessões (grupo)</ItemTitle>
-                  <ItemNumber>5</ItemNumber>
-                </GridItem>
-              </Col>
-            </Row>
-          </LayoutBackground>
+          {userRole !== 'patient' && (
+            <LayoutBackground>
+              <Row gutter={[20, 20]} wrap>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Sessões agendadas (dia)</ItemTitle>
+                    <ItemNumber>5</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Sessões agendadas (mês)</ItemTitle>
+                    <ItemNumber>15</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Sessões canceladas (mês)</ItemTitle>
+                    <ItemNumber>1</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Total de pacientes cadastrados</ItemTitle>
+                    <ItemNumber>61152</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Total de sessões (individuais)</ItemTitle>
+                    <ItemNumber>5</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Total de sessões (dupla)</ItemTitle>
+                    <ItemNumber>5</ItemNumber>
+                  </GridItem>
+                </Col>
+                <Col>
+                  <GridItem>
+                    <ItemTitle>Total de sessões (grupo)</ItemTitle>
+                    <ItemNumber>5</ItemNumber>
+                  </GridItem>
+                </Col>
+              </Row>
+            </LayoutBackground>
+          )}
         </Content>
         <Footer
           style={{

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,7 +1,14 @@
-import { Col, Layout, Row } from 'antd';
+import { Col, Layout, Row, Divider, Descriptions, Badge } from 'antd';
 import { getUserRole } from 'src/services/Auth/service';
 import SideMenu from '../SideMenu/SideMenu';
-import { GridItem, ItemNumber, ItemTitle, LayoutBackground } from './DashboardStyles';
+import {
+  GridItem,
+  PatientGridItem,
+  ItemNumber,
+  ItemTitle,
+  LayoutBackground,
+  PatientItemTitle,
+} from './DashboardStyles';
 
 const Dashboard: React.FC = () => {
   const currentPath = window.location.pathname;
@@ -16,6 +23,32 @@ const Dashboard: React.FC = () => {
           style={{
             margin: '25px 20px',
           }}>
+          <LayoutBackground>
+            <Row gutter={[0, 40]} wrap>
+              <Col span={24}>
+                <PatientGridItem>
+                  <PatientItemTitle>Titulo da sessao</PatientItemTitle>
+                  <Divider />
+                  <Descriptions layout="vertical" bordered>
+                    <Descriptions.Item label="Status" span={3}>
+                      <Badge status="processing" text="Running" />
+                    </Descriptions.Item>
+                  </Descriptions>
+                </PatientGridItem>
+              </Col>
+              <Col span={24}>
+                <PatientGridItem>
+                  <PatientItemTitle>Titulo da sessao</PatientItemTitle>
+                  <Divider />
+                  <Descriptions layout="vertical" bordered>
+                    <Descriptions.Item label="Status" span={3}>
+                      <Badge status="processing" text="Running" />
+                    </Descriptions.Item>
+                  </Descriptions>
+                </PatientGridItem>
+              </Col>
+            </Row>
+          </LayoutBackground>
           {userRole !== 'patient' && (
             <LayoutBackground>
               <Row gutter={[20, 20]} wrap>

--- a/src/components/Dashboard/DashboardStyles.ts
+++ b/src/components/Dashboard/DashboardStyles.ts
@@ -9,8 +9,7 @@ export const LayoutBackground = styled.div`
 export const PatientGridItem = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 20px;
+  padding: 35px;
   background: white;
   border-radius: 10px;
   box-shadow: 14px 18px 23px -11px rgba(0, 0, 0, 0.35);
@@ -38,4 +37,5 @@ export const ItemNumber = styled.span`
 
 export const PatientItemTitle = styled.h1`
   margin-top: 10px;
+  font-size: 25px;
 `;

--- a/src/components/Dashboard/DashboardStyles.ts
+++ b/src/components/Dashboard/DashboardStyles.ts
@@ -6,6 +6,17 @@ export const LayoutBackground = styled.div`
   min-height: 360px;
 `;
 
+export const PatientGridItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 14px 18px 23px -11px rgba(0, 0, 0, 0.35);
+  width: 100%;
+`;
+
 export const GridItem = styled.div`
   display: flex;
   flex-direction: column;
@@ -23,4 +34,8 @@ export const ItemTitle = styled.span`
 
 export const ItemNumber = styled.span`
   font-size: 35px;
+`;
+
+export const PatientItemTitle = styled.h1`
+  margin-top: 10px;
 `;

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -2,7 +2,7 @@ import { CalendarOutlined, HomeOutlined, UserOutlined } from '@ant-design/icons'
 import { Image, Layout, Menu, Typography } from 'antd';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { isAuthenticated } from 'src/services/Auth/service';
+import { isAuthenticated, getUserRole } from 'src/services/Auth/service';
 import { LogoTitle } from './SideMenuStyles';
 
 const SideMenu: React.FC = () => {
@@ -10,6 +10,8 @@ const SideMenu: React.FC = () => {
   const { Title } = Typography;
   const navigate = useNavigate();
   const location = useLocation();
+  const userRole = getUserRole();
+  const isProfessionalAuthenticated = isAuthenticated() && userRole !== 'patient';
 
   const clickHandler = (item: { key: string }) => {
     if (item.key === '1') {
@@ -23,10 +25,22 @@ const SideMenu: React.FC = () => {
     }
   };
 
+  const patientClickHandler = (item: { key: string }) => {
+    if (item.key === '1') {
+      navigate('/patients-dashboard');
+    }
+  };
+
   const returnDefaultSelectedKeys = (): string[] | undefined => {
     if (location.pathname === '/') return ['1'];
     if (location.pathname === '/patients') return ['2'];
     if (location.pathname === '/sessions') return ['3'];
+
+    return [''];
+  };
+
+  const returnPatientDefaultSelectedKeys = (): string[] | undefined => {
+    if (location.pathname === '/patients-dashboard') return ['1'];
 
     return [''];
   };
@@ -37,6 +51,8 @@ const SideMenu: React.FC = () => {
 
     return 'Sessões';
   };
+
+  const indexToPatientName = () => 'Minhas sessões';
 
   return (
     <Sider>
@@ -49,7 +65,6 @@ const SideMenu: React.FC = () => {
               marginTop: '20px',
             }}
           />
-          {/* <img src="public/mente-sa-logo.png" alt="Mente Sã logo"></img> */}
           <Title
             style={{
               color: 'white',
@@ -60,6 +75,19 @@ const SideMenu: React.FC = () => {
           </Title>
         </LogoTitle>
         {isAuthenticated() && (
+          <Menu
+            theme="dark"
+            mode="inline"
+            defaultSelectedKeys={returnPatientDefaultSelectedKeys()}
+            onClick={patientClickHandler}
+            items={[CalendarOutlined].map((icon, index) => ({
+              key: String(index + 1),
+              icon: React.createElement(icon),
+              label: indexToPatientName(),
+            }))}
+          />
+        )}
+        {isProfessionalAuthenticated && (
           <Menu
             theme="dark"
             mode="inline"

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -11,7 +11,8 @@ const SideMenu: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const userRole = getUserRole();
-  const isProfessionalAuthenticated = isAuthenticated() && userRole !== 'patient';
+  const isProfessionalAuthenticated = isAuthenticated() && userRole === 'professional';
+  const isPatientAuthenticated = isAuthenticated() && userRole === 'patient';
 
   const clickHandler = (item: { key: string }) => {
     if (item.key === '1') {
@@ -27,7 +28,7 @@ const SideMenu: React.FC = () => {
 
   const patientClickHandler = (item: { key: string }) => {
     if (item.key === '1') {
-      navigate('/patients-dashboard');
+      navigate('/dashboard');
     }
   };
 
@@ -40,7 +41,7 @@ const SideMenu: React.FC = () => {
   };
 
   const returnPatientDefaultSelectedKeys = (): string[] | undefined => {
-    if (location.pathname === '/patients-dashboard') return ['1'];
+    if (userRole === 'patient') return ['1'];
 
     return [''];
   };
@@ -74,7 +75,7 @@ const SideMenu: React.FC = () => {
             Mente Sã
           </Title>
         </LogoTitle>
-        {isAuthenticated() && (
+        {isPatientAuthenticated && (
           <Menu
             theme="dark"
             mode="inline"

--- a/src/services/Auth/service.ts
+++ b/src/services/Auth/service.ts
@@ -7,7 +7,7 @@ export const TOKEN_KEY = '@menteSa-Token';
 export const REFRESH_TOKEN = '@menteSa-RefreshTokem';
 export const USER_EMAIL = '@menteSa-UserEmail';
 export const USER_ROLE = '@menteSa-UserRole';
-export const CURRENT_WORKER_ID = '@menteSa-CurrentWorkerId';
+export const CURRENT_USER_ID = '@menteSa-CurrentUserId';
 export const SWORDFISH = '@menteSa-Swordfish';
 
 export async function fetchLoginUser(
@@ -19,7 +19,7 @@ export async function fetchLoginUser(
   const { data, status } = await api.post(url, payload);
 
   if (status === 200) {
-    localStorage.setItem(CURRENT_WORKER_ID, JSON.stringify(data.id));
+    localStorage.setItem(CURRENT_USER_ID, JSON.stringify(data.id));
     localStorage.setItem(TOKEN_KEY, JSON.stringify(data.accessToken));
     localStorage.setItem(USER_ROLE, JSON.stringify('professional'));
 
@@ -31,7 +31,7 @@ export async function fetchLoginUser(
 }
 
 export const getUserRole = () => localStorage.getItem(USER_ROLE)?.replace(/[""]+/g, '');
-export const getCurrentWorkerId = () => localStorage.getItem(CURRENT_WORKER_ID);
+export const getCurrentWorkerId = () => localStorage.getItem(CURRENT_USER_ID);
 export const getCurrentSwordfish = () => localStorage.getItem(SWORDFISH);
 export const isAuthenticated = () => localStorage.getItem(TOKEN_KEY) !== null;
 export const getToken = () => localStorage.getItem(TOKEN_KEY);
@@ -41,7 +41,7 @@ export const getUserEmail = () => localStorage.getItem(USER_EMAIL)?.replace(/[""
 export const logout = () => {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN);
-  localStorage.removeItem(CURRENT_WORKER_ID);
+  localStorage.removeItem(CURRENT_USER_ID);
 };
 
 export async function fetchRefreshToken({
@@ -52,7 +52,7 @@ export async function fetchRefreshToken({
   const { data, status } = await api.post(url, { refreshToken });
 
   if (status === 200) {
-    localStorage.setItem(CURRENT_WORKER_ID, JSON.stringify(data.id));
+    localStorage.setItem(CURRENT_USER_ID, JSON.stringify(data.id));
   }
   return data;
 }
@@ -68,7 +68,7 @@ export async function fetchRegisterUser({
   const { data, status } = await api.post(url, payload);
 
   if (status === 201) {
-    localStorage.setItem(CURRENT_WORKER_ID, JSON.stringify(data.id));
+    localStorage.setItem(CURRENT_USER_ID, JSON.stringify(data.id));
   }
   return data;
 }

--- a/src/services/Auth/service.ts
+++ b/src/services/Auth/service.ts
@@ -21,7 +21,7 @@ export async function fetchLoginUser(
   if (status === 200) {
     localStorage.setItem(CURRENT_WORKER_ID, JSON.stringify(data.id));
     localStorage.setItem(TOKEN_KEY, JSON.stringify(data.accessToken));
-    localStorage.setItem(USER_ROLE, JSON.stringify('patient'));
+    localStorage.setItem(USER_ROLE, JSON.stringify('professional'));
 
     if (remember) {
       localStorage.setItem(REFRESH_TOKEN, data.refreshToken);

--- a/src/services/Auth/service.ts
+++ b/src/services/Auth/service.ts
@@ -7,6 +7,7 @@ import { IAuthLoginParser, IRefreshTokenParser } from './dtos/IAuthParser';
 export const TOKEN_KEY = '@menteSa-Token';
 export const REFRESH_TOKEN = '@menteSa-RefreshTokem';
 export const USER_EMAIL = '@menteSa-UserEmail';
+export const USER_ROLE = '@menteSa-UserRole';
 export const CURRENT_WORKER_ID = '@menteSa-CurrentWorkerId';
 export const SWORDFISH = '@menteSa-Swordfish';
 
@@ -21,16 +22,18 @@ export async function fetchLoginUser({
   if (status === 200) {
     localStorage.setItem(CURRENT_WORKER_ID, JSON.stringify(data.id));
     localStorage.setItem(TOKEN_KEY, JSON.stringify(data.accessToken));
+    localStorage.setItem(USER_ROLE, JSON.stringify('patient'));
   }
   return data;
 }
 
+export const getUserRole = () => localStorage.getItem(USER_ROLE)?.replace(/[""]+/g, '');
 export const getCurrentWorkerId = () => localStorage.getItem(CURRENT_WORKER_ID);
 export const getCurrentSwordfish = () => localStorage.getItem(SWORDFISH);
 export const isAuthenticated = () => localStorage.getItem(TOKEN_KEY) !== null;
 export const getToken = () => localStorage.getItem(TOKEN_KEY);
 export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN);
-export const getUserEmail = () => localStorage.getItem(USER_EMAIL);
+export const getUserEmail = () => localStorage.getItem(USER_EMAIL)?.replace(/[""]+/g, '');
 
 export const logout = () => {
   localStorage.removeItem(TOKEN_KEY);

--- a/src/services/api.tsx
+++ b/src/services/api.tsx
@@ -21,7 +21,7 @@ api.interceptors.response.use(
   },
   async (error) => {
     const refresh_token = getRefreshToken();
-    const user_email = getUserEmail()?.replace(/[""]+/g, '');
+    const user_email = getUserEmail();
 
     if (error.response.status === 401 && refresh_token && user_email) {
       const response = await fetchRefreshToken({


### PR DESCRIPTION
## Qual é o propósito desse PR?
- Adiciona separação por `userRole` do usuário. Profissional (`professional`) terá a tela de exibição completa e Paciente (`patient`) verá apenas a sessão `Minhas sessões` disponível na sua barra lateral.

## Lista do que foi feito:
- Adiciona condicionais a pagina de `Dashboard` para pacientes ou profissionais logados.
- Layout da tela inicial de exibição de sessões do paciente logado.

## Há algo fora do propósito do card ?
- Sim!! Objeto de listagem esta HARD CODED!! Deve-se criar no back end para poder listar as sessoes de acordo com o paciente logado. 

## Como pode ser testado?
- Para testar deve-se primeiro ir no arquivo `src/services/Auth/service.ts` e mudar a linha `localStorage.setItem(USER_ROLE, JSON.stringify('professional'));` para que armazene `'patient'`. Para que, o usuário, ao logar armazene essa informacao no local storage e cumprir com as condicionais para exibir tela de sessoes de pacientes. Por enquanto está hard coded. Deve-se alterar para back end devolver tal informacao junto com token.
____
**Link da Issue**

[Veirificar Issue](https://github.com/william-ribeiro/web-healthy-mind/issues/1)
