### PR TITLE
[add-pagination-feature] - Adiciona paginação a listagem de sessões e pacientes.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Login from 'src/pages/LogIn/Login';
 import Dashboard from 'src/pages/Main/Main';
 import Patients from 'src/pages/Patients/Patients';
 import './App.css';
+import PatientCalendar from './components/PatientCalendar/PatientCalendar';
 
 import FormPatient from './components/FormPatient/FormPatient';
 import FormSession from './components/FormSession/FormSession';
@@ -45,6 +46,15 @@ const App: React.FC = () => {
             element={
               <PrivateRoute redirectTo="/">
                 <Patients />
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/patient-calendar"
+            element={
+              <PrivateRoute redirectTo="/">
+                <PatientCalendar />
               </PrivateRoute>
             }
           />

--- a/src/components/PatientCalendar/PatientCalendar.tsx
+++ b/src/components/PatientCalendar/PatientCalendar.tsx
@@ -1,0 +1,93 @@
+import type { BadgeProps } from 'antd';
+import { Badge, Calendar, Layout } from 'antd';
+import type { Moment } from 'moment';
+import React from 'react';
+import { NotesMonth, NotesMonthSection, Events } from './PatientCalendarStyles';
+import SideMenu from '../SideMenu/SideMenu';
+
+const getListData = (value: Moment) => {
+  let listData;
+  switch (value.date()) {
+    case 8:
+      listData = [
+        { type: 'warning', content: 'This is warning event.' },
+        { type: 'success', content: 'This is usual event.' },
+      ];
+      break;
+    case 10:
+      listData = [
+        { type: 'warning', content: 'This is warning event.' },
+        { type: 'success', content: 'This is usual event.' },
+        { type: 'error', content: 'This is error event.' },
+      ];
+      break;
+    case 15:
+      listData = [
+        { type: 'warning', content: 'This is warning event' },
+        { type: 'success', content: 'This is very long usual event。。....' },
+        { type: 'error', content: 'This is error event 1.' },
+        { type: 'error', content: 'This is error event 2.' },
+        { type: 'error', content: 'This is error event 3.' },
+        { type: 'error', content: 'This is error event 4.' },
+      ];
+      break;
+    default:
+  }
+  return listData || [];
+};
+
+// eslint-disable-next-line consistent-return
+const getMonthData = (value: Moment) => {
+  if (value.month() === 8) {
+    return 1394;
+  }
+};
+
+const PatientCalendar: React.FC = () => {
+  const { Content, Footer } = Layout;
+
+  const monthCellRender = (value: Moment) => {
+    const num = getMonthData(value);
+    return num ? (
+      <NotesMonth>
+        <NotesMonthSection>{num}</NotesMonthSection>
+        <span>Backlog number</span>
+      </NotesMonth>
+    ) : null;
+  };
+
+  const dateCellRender = (value: Moment) => {
+    const listData = getListData(value);
+    return (
+      <Events>
+        {listData.map((item) => (
+          <li key={item.content}>
+            <Badge status={item.type as BadgeProps['status']} text={item.content} />
+          </li>
+        ))}
+      </Events>
+    );
+  };
+
+  return (
+    <Layout style={{ minHeight: '100vh' }}>
+      <SideMenu />
+      <Layout>
+        <Content
+          style={{
+            margin: '25px 20px',
+          }}>
+          <Calendar dateCellRender={dateCellRender} monthCellRender={monthCellRender} />;
+        </Content>
+        <Footer
+          style={{
+            textAlign: 'center',
+          }}>
+          Mente Sã ©2022 Created by Dev4Tech
+        </Footer>
+      </Layout>
+    </Layout>
+  );
+};
+
+export default PatientCalendar;

--- a/src/components/PatientCalendar/PatientCalendarStyles.ts
+++ b/src/components/PatientCalendar/PatientCalendarStyles.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const NotesMonth = styled.div`
+  font-size: 28px;
+  text-align: center;
+`;
+
+export const NotesMonthSection = styled.section`
+  font-size: 28px;
+`;
+
+export const Events = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  &.ant-badge-status {
+    width: 100%;
+    overflow: hidden;
+    font-size: 12px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+`;
+
+export const Badge = styled.ul`
+  width: 100%;
+  overflow: hidden;
+  font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;

--- a/src/components/PatientsList/PatientsList.tsx
+++ b/src/components/PatientsList/PatientsList.tsx
@@ -213,6 +213,7 @@ const PatientsList: React.FC = () => {
                 dataSource={data}
                 loading={isLoading}
                 columns={columns}
+                pagination={{ pageSize: 10 }}
                 style={{
                   width: `100%`,
                 }}

--- a/src/components/SessionsList/SessionsList.tsx
+++ b/src/components/SessionsList/SessionsList.tsx
@@ -181,6 +181,7 @@ const SessionsList: React.FC = () => {
               loading={isLoading}
               dataSource={data}
               columns={columns}
+              pagination={{ pageSize: 10 }}
               style={{
                 width: `100%`,
               }}

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -1,4 +1,10 @@
-import { CalendarOutlined, HomeOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
+import {
+  CalendarOutlined,
+  ClockCircleOutlined,
+  HomeOutlined,
+  LogoutOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
 import { Image, Layout, Menu, Typography } from 'antd';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -35,6 +41,9 @@ const SideMenu: React.FC = () => {
       navigate('/dashboard');
     }
     if (item.key === '2') {
+      navigate('/patient-calendar');
+    }
+    if (item.key === '3') {
       logout();
       navigate('/');
     }
@@ -49,7 +58,8 @@ const SideMenu: React.FC = () => {
   };
 
   const returnPatientDefaultSelectedKeys = (): string[] | undefined => {
-    if (userRole === '3') return ['1'];
+    if (userRole === '3' && location.pathname === '/dashboard') return ['1'];
+    if (userRole === '3' && location.pathname === '/patient-calendar') return ['2'];
 
     return [''];
   };
@@ -64,6 +74,7 @@ const SideMenu: React.FC = () => {
 
   const indexToPatientName = (index: number) => {
     if (index === 0) return 'Minhas sessões';
+    if (index === 1) return 'Calendário';
     return 'Logout';
   };
 
@@ -93,7 +104,7 @@ const SideMenu: React.FC = () => {
             mode="inline"
             defaultSelectedKeys={returnPatientDefaultSelectedKeys()}
             onClick={patientClickHandler}
-            items={[CalendarOutlined, LogoutOutlined].map((icon, index) => ({
+            items={[ClockCircleOutlined, CalendarOutlined, LogoutOutlined].map((icon, index) => ({
               key: String(index + 1),
               icon: React.createElement(icon),
               label: indexToPatientName(index),

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import Dashboard from 'src/components/Dashboard/Dashboard';
-// import { isAuthenticated } from "src/services/Auth/service";
-// import { UserResponseDto } from "src/services/Patient/dtos/UserResponse.dto";
-// import { useUserList } from "src/services/Patient/hooks";
 
 const TsPage: React.FC = () => {
-  // const {data} = useUserList();
-  // const [users, setUsers] = useState<UserResponseDto[] | undefined >()
-
-  // useEffect(()=>{
-  //     setUsers(data)
-  // },[data])
-
   return <Dashboard />;
 };
 


### PR DESCRIPTION
## Qual é o propósito desse PR?
- Adicionar paginação a listagem de sessões e pacientes (10 por página).

## Lista do que foi feito:
- Adiciona paginação a listagem de sessões e pacientes (10 por página).

## Há algo fora do propósito do card ?
- Adiciona calendário inicial a tela de dashboard do paciente logado.

## Como pode ser testado?
- [PAGINAÇÃO] Nas telas de listagem de sessões e/ou pacientes, criar +10 ou mudar o campo de `pagination` no componente `Table` dessas listagens pra 1 por exemplo, forçando paginação.
- [CALENDÁRIO] Logado como paciente, deve aparecer um novo campo de `Calendário`, ao clicar nele deve aparecer um calendário inicial funcionando, exibindo um exemplo hard coded de como podemos exibir as sessões do paciente agendadas.
____
**Link da Issue**
